### PR TITLE
Figure scripts review (#7061)

### DIFF
--- a/components/tools/OmeroPy/scripts/omero/export_scripts/Batch_Image_Export.py
+++ b/components/tools/OmeroPy/scripts/omero/export_scripts/Batch_Image_Export.py
@@ -310,20 +310,30 @@ def batchImageExport(conn, scriptParams):
         return tRange
 
     # images to export
+    message = ""
     images = []
     objects = conn.getObjects(dataType, ids)    # images or datasets
     parentToAttachZip = None
     if dataType == 'Dataset':
-        for ds in objects:
+        datasets = list(objects)
+        for ds in datasets:
             if parentToAttachZip is None:
                 parentToAttachZip = ds
             images.extend( list(ds.listChildren()) )
         if not images:
-            raise Exception('No images found in dataset')
+            message += "No image found in dataset. "
+            return None, message
+        else:
+            if not len(datasets) == len(ids):
+                message += "Found %s out of %s dataset(s). " %  (len(datasets), len(ids))
     else:
         images = list(objects)
         if not images:
-            raise Exception('No images found')
+            message += "No image found. "
+            return None, message
+        else:
+            if not len(images) == len(ids):
+                message += "Found %s out of %s image(s). " % (len(images), len(ids))
         parentToAttachZip = images[0]
     log("Processing %s images" % len(images))
     
@@ -388,13 +398,17 @@ def batchImageExport(conn, scriptParams):
 
     if os.path.exists(export_file):
         fileAnn = conn.createFileAnnfromLocalFile(export_file, mimetype=mimetype, desc=None)
+        message += "Batch export zip created"
         if parentToAttachZip is not None:
             if parentToAttachZip.canAnnotate():
+                message += " and attached to %s %s."  % (scriptParams['Data_Type'], parentToAttachZip.getName())
                 log("Attaching zip to... %s %s %s" % (scriptParams['Data_Type'], parentToAttachZip.getName(), parentToAttachZip.getId()) )
                 parentToAttachZip.linkAnnotation(fileAnn)
             else:
-                return fileAnn, None
-        return fileAnn, parentToAttachZip
+                message += " but could not be attached."
+    else:
+        fileAnn = None
+    return fileAnn, message
 
 def runScript():
     """
@@ -476,38 +490,32 @@ See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/r
     contact = "ome-users@lists.openmicroscopy.org.uk",
     ) 
     
-    startTime = datetime.now()
-    session = client.getSession()
-    scriptParams = {}
-
-    conn = BlitzGateway(client_obj=client)
-    
-    # process the list of args above. 
-    for key in client.getInputKeys():
-        if client.getInput(key):
-            scriptParams[key] = client.getInput(key, unwrap=True)
-    log(scriptParams)
-    # call the main script - returns a file annotation wrapper
     try:
-        result = batchImageExport(conn, scriptParams)
-    except Exception, e:
-        message = "Failed. "
-        message += str(e)
-        client.setOutput("Message", rstring(message))
-        result = None
+        startTime = datetime.now()
+        session = client.getSession()
+        scriptParams = {}
 
-    stopTime = datetime.now()
-    log("Duration: %s" % str(stopTime-startTime))
+        conn = BlitzGateway(client_obj=client)
 
-    # return this fileAnnotation to the client. 
-    if result is not None:
-        fileAnnWrapper, parentToAttachZip = result
-        message = "Batch Export zip created"
-        if parentToAttachZip is not None:
-            message += " and attached to %s %s"  % (scriptParams['Data_Type'], parentToAttachZip.getName())        
-        client.setOutput("File_Annotation", robject(fileAnnWrapper._obj))
+        # process the list of args above. 
+        for key in client.getInputKeys():
+            if client.getInput(key):
+                scriptParams[key] = client.getInput(key, unwrap=True)
+        log(scriptParams)
+
+        # call the main script - returns a file annotation wrapper
+        fileAnnotation, message = batchImageExport(conn, scriptParams)
+        
+        stopTime = datetime.now()
+        log("Duration: %s" % str(stopTime-startTime))
+
+        # return this fileAnnotation to the client. 
         client.setOutput("Message", rstring(message))
-    
+        if fileAnnotation is not None:
+                client.setOutput("File_Annotation", robject(fileAnnotation._obj))
+                    
+    finally:
+        client.closeSession()
 
 if __name__ == "__main__":
     runScript()

--- a/components/tools/OmeroPy/scripts/omero/export_scripts/Batch_Image_Export.py
+++ b/components/tools/OmeroPy/scripts/omero/export_scripts/Batch_Image_Export.py
@@ -396,19 +396,10 @@ def batchImageExport(conn, scriptParams):
         compress(export_file, folder_name)
         mimetype='zip'
 
-    if os.path.exists(export_file):
-        fileAnn = conn.createFileAnnfromLocalFile(export_file, mimetype=mimetype, desc=None)
-        message += "Batch export zip created"
-        if parentToAttachZip is not None:
-            if parentToAttachZip.canAnnotate():
-                message += " and attached to %s %s."  % (scriptParams['Data_Type'], parentToAttachZip.getName())
-                log("Attaching zip to... %s %s %s" % (scriptParams['Data_Type'], parentToAttachZip.getName(), parentToAttachZip.getId()) )
-                parentToAttachZip.linkAnnotation(fileAnn)
-            else:
-                message += " but could not be attached."
-    else:
-        fileAnn = None
-    return fileAnn, message
+    fileAnnotation, annMessage = script_utils.createLinkFileAnnotation(conn, export_file, parentToAttachZip, 
+        output="Batch export zip", parenttype=scriptParams["Data_Type"], mimetype=mimetype)
+    message += annMessage
+    return fileAnnotation, message
 
 def runScript():
     """

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
@@ -517,7 +517,7 @@ def movieFigure(conn, commandArgs):
         mimetype = "image/jpeg"
     
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie figure", parenttype=commandArgs["Data_Type"], mimetype=mimetype, desc=figLegend)
+    output="Movie figure", mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
@@ -514,12 +514,14 @@ def movieFigure(conn, commandArgs):
     if format == PNG:
         output = output + ".png"
         figure.save(output, "PNG")
+        mimetype = "image/png"
     else:
         output = output + ".jpg"
         figure.save(output)
+        mimetype = "image/jpeg"
     
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie figure", parenttype=commandArgs["Data_Type"], mimetype=format, desc=figLegend)
+    output="Movie figure", parenttype=commandArgs["Data_Type"], mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
@@ -512,8 +512,9 @@ def movieFigure(conn, commandArgs):
         figure.save(output)
         mimetype = "image/jpeg"
     
+    namespace = omero.constants.namespaces.NSCREATED+"/figure/movieFigure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie figure", mimetype=mimetype, desc=figLegend)
+    output="Movie figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
@@ -512,7 +512,7 @@ def movieFigure(conn, commandArgs):
         figure.save(output)
         mimetype = "image/jpeg"
     
-    namespace = omero.constants.namespaces.NSCREATED+"/figure/movieFigure"
+    namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Movie_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
     output="Movie figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_Figure.py
@@ -369,7 +369,7 @@ def movieFigure(conn, commandArgs):
     pixelIds = []
     imageIds = []
     imageLabels = []
-    message = ""
+    message = "" # message to be returned to the client
 
     # function for getting image labels.
     def getLabels(fullName, tagsList, pdList):
@@ -387,24 +387,20 @@ def movieFigure(conn, commandArgs):
                 return tagsList
             getLabels = getTags
   
+    # Get the images
+    images, logMessage = scriptUtil.getObjects(conn, commandArgs)
+    message += logMessage
+    if not images:
+        return None, message
+    
+    # Attach figure to the first image
+    omeroImage = images[0]
+    
     # process the list of images
     log("Image details:")
-    ids = commandArgs["IDs"]
-    images = list(conn.getObjects("Image",ids))
-
-    # Check images
-    if not images:
-        message += "No image found. "
-        return None, message
-    else:
-        if not len(images) == len(ids):
-            message += "Found %s out of %s image(s). " % (len(images), len(ids))
-
     for image in images:
         imageIds.append(image.getId())
         pixelIds.append(image.getPrimaryPixels().getId())
-
-    omeroImage = images[0]
   
     pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
     tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -41,6 +41,7 @@ import omero.scripts as scripts
 import omero.util.imageUtil as imgUtil
 import omero.util.figureUtil as figUtil
 import omero.util.script_utils as scriptUtil
+from omero.gateway import BlitzGateway
 from omero.model import ImageI
 from omero.rtypes import *      # includes wrap()
 # import util.figureUtil as figUtil    # need to comment out for upload to work. But need import for script to work!!
@@ -347,7 +348,7 @@ def getVerticalLabels(labels, font, textGap):
     return textCanvas.rotate(90)
     
     
-def getSplitView(session, imageIds, pixelIds, mergedIndexes, 
+def getSplitView(conn, imageIds, pixelIds, mergedIndexes,
         mergedColours, width, height, imageLabels, spacer, algorithm, stepping, scalebar, 
         overlayColour, roiZoom, maxColumns, showRoiDuration, roiLabel):
     """ This method makes a figure of a number of images, arranged in rows with each row being the split-view
@@ -366,9 +367,9 @@ def getSplitView(session, imageIds, pixelIds, mergedIndexes,
     @ spacer        the gap between images and around the figure. Doubled between rows. 
     """
     
-    roiService = session.getRoiService()
-    re = session.createRenderingEngine()
-    queryService = session.getQueryService()    # only needed for movie
+    roiService = conn.getRoiService()
+    re = conn.createRenderingEngine()
+    queryService = conn.getQueryService()    # only needed for movie
     
     # establish dimensions and roiZoom for the primary image
     # getTheseValues from the server
@@ -493,9 +494,8 @@ def getSplitView(session, imageIds, pixelIds, mergedIndexes,
         rowY = rowY + max(image.size[1]+topSpacers[row], roiSplitPanes[row].size[1])+ spacer
 
     return figureCanvas
-            
 
-def roiFigure(session, commandArgs):    
+def roiFigure(conn, commandArgs):
     """
         This processes the script parameters, adding defaults if needed. 
         Then calls a method to make the figure, and finally uploads and attaches this to the primary image.
@@ -507,13 +507,6 @@ def roiFigure(session, commandArgs):
         
         @return:     the id of the originalFileLink child. (ID object, not value) 
     """
-    
-    # create the services we're going to need. 
-    metadataService = session.getMetadataService()
-    queryService = session.getQueryService()
-    updateService = session.getUpdateService()
-    rawFileStore = session.createRawFileStore()
-    containerService = session.getContainerService()
     
     log("ROI figure created by OMERO on %s" % date.today())
     log("")
@@ -540,30 +533,29 @@ def roiFigure(session, commandArgs):
                 return tagsList
             getLabels = getTags
             
-    # process the list of images. If imageIds is not set, script can't run. 
+    # process the list of images. If imageIds is not set, script can't run.
     log("Image details:")
-    dataType = commandArgs["Data_Type"]
-    ids = commandArgs["IDs"]
-    images = containerService.getImages(dataType, ids, None)
-
-    for idCount, image in enumerate(images):
-        iId = image.getId().getValue()
-        imageIds.append(iId)
-        if idCount == 0:
+    for imageId in commandArgs["IDs"]:
+        image = conn.getObject("Image", imageId)
+        if image == None:
+            print "Image not found for ID:", imageId
+            continue
+        imageIds.append(imageId)
+        if omeroImage is None:
             omeroImage = image        # remember the first image to attach figure to
-        pixelIds.append(image.getPrimaryPixels().getId().getValue())
-        imageNames[iId] = image.getName().getValue()
+        pixelIds.append(image.getPrimaryPixels().getId())
+        imageNames[imageId] = image.getName()
 
     if len(imageIds) == 0:
         print "No image IDs specified."
         return
             
-    pdMap = figUtil.getDatasetsProjectsFromImages(queryService, imageIds)    # a map of imageId : list of (project, dataset) names. 
-    tagMap = figUtil.getTagsFromImages(metadataService, imageIds)
+    pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
+    tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)
     # Build a legend entry for each image
     for iId in imageIds:
         name = imageNames[iId]
-        imageDate = image.getAcquisitionDate().getValue()
+        imageDate = image.getAcquisitionDate()
         tagsList = tagMap[iId]
         pdList = pdMap[iId]
         
@@ -577,13 +569,10 @@ def roiFigure(session, commandArgs):
         imageLabels.append(getLabels(name, tagsList, pdList))
     
     # use the first image to define dimensions, channel colours etc. 
-    pixelsId = pixelIds[0]
-    pixels = queryService.get("Pixels", pixelsId)
-
-    sizeX = pixels.getSizeX().getValue();
-    sizeY = pixels.getSizeY().getValue();
-    sizeZ = pixels.getSizeZ().getValue();
-    sizeC = pixels.getSizeC().getValue();
+    sizeX = omeroImage.getSizeX();
+    sizeY = omeroImage.getSizeY();
+    sizeZ = omeroImage.getSizeZ();
+    sizeC = omeroImage.getSizeC();
     
     width = sizeX
     if "Width" in commandArgs:
@@ -669,7 +658,7 @@ def roiFigure(session, commandArgs):
     spacer = (width/50) + 2
     
     print "showRoiDuration", showRoiDuration
-    fig = getSplitView(session, imageIds, pixelIds, mergedIndexes, 
+    fig = getSplitView(conn, imageIds, pixelIds, mergedIndexes,
             mergedColours, width, height, imageLabels, spacer, algorithm, stepping, scalebar, overlayColour, roiZoom, 
             maxColumns, showRoiDuration, roiLabel)
                                                     
@@ -701,8 +690,13 @@ def roiFigure(session, commandArgs):
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
-    fileAnnotation = scriptUtil.uploadAndAttachFile(queryService, updateService, rawFileStore, omeroImage, output, format, figLegend)
-    return (fileAnnotation, omeroImage)
+    fileAnnotation = conn.createFileAnnfromLocalFile(output, mimetype=format, desc=figLegend)
+    if omeroImage.canAnnotate():
+        log("Attaching figure to image %s %s" % (omeroImage.getName(), omeroImage.getId()) )
+        omeroImage.linkAnnotation(fileAnnotation)
+        return fileAnnotation, omeroImage
+    else:
+        return fileAnnotation, None
 
 def runAsScript():
     """
@@ -783,6 +777,7 @@ See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/e
     try:
         session = client.getSession();
         commandArgs = {}
+        conn = BlitzGateway(client_obj=client)
 
         # process the list of args above. 
         for key in client.getInputKeys():
@@ -791,13 +786,15 @@ See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/e
 
         print commandArgs
         # call the main script, attaching resulting figure to Image. Returns the id of the originalFileLink child. (ID object, not value)
-        result = roiFigure(session, commandArgs)
+        result = roiFigure(conn, commandArgs)
         if result is not None:
             fileAnnotation, image = result
-            # return this fileAnnotation to the client. 
-            if fileAnnotation:
-                client.setOutput("Message", rstring("ROI Movie Figure Attached to Image: %s" % image.name.val))
-                client.setOutput("File_Annotation", robject(fileAnnotation))
+            fileAnnotation, image = result
+            message = "ROI Movie Figure created"
+            if image is not None:
+                message += " and attached to image %s"  % image.getName()
+            client.setOutput("File_Annotation", robject(fileAnnotation._obj)) # return this fileAnnotation to the client. 
+            client.setOutput("Message", rstring(message))
         else:
             client.setOutput("Message", rstring("No Figure Produced. See Error or Info for details"))
 

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -690,7 +690,7 @@ def roiFigure(conn, commandArgs):
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
-    namespace = omero.constants.namespaces.NSCREATED+"/figure/movieROIFigure"
+    namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Movie_ROI_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
     output="Movie ROI figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -696,7 +696,7 @@ def roiFigure(conn, commandArgs):
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie ROI figure", parenttype=commandArgs["Data_Type"], mimetype=mimetype, desc=figLegend)
+    output="Movie ROI figure", mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -511,6 +511,7 @@ def roiFigure(conn, commandArgs):
     log("ROI figure created by OMERO on %s" % date.today())
     log("")
     
+    message=""
     pixelIds = []
     imageIds = []
     imageLabels = []
@@ -535,7 +536,8 @@ def roiFigure(conn, commandArgs):
             
     # process the list of images. If imageIds is not set, script can't run.
     log("Image details:")
-    for imageId in commandArgs["IDs"]:
+    ids = commandArgs["IDs"]
+    for imageId in ids:
         image = conn.getObject("Image", imageId)
         if image == None:
             print "Image not found for ID:", imageId
@@ -548,7 +550,11 @@ def roiFigure(conn, commandArgs):
 
     if len(imageIds) == 0:
         print "No image IDs specified."
-        return
+        message += "No image found. "
+        return None, message
+    else:
+        if not len(imageIds) == len(ids):
+            message += "Found %s out of %s image(s). " % (len(imageIds), len(ids))
             
     pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
     tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)
@@ -690,13 +696,11 @@ def roiFigure(conn, commandArgs):
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
-    fileAnnotation = conn.createFileAnnfromLocalFile(output, mimetype=format, desc=figLegend)
-    if omeroImage.canAnnotate():
-        log("Attaching figure to image %s %s" % (omeroImage.getName(), omeroImage.getId()) )
-        omeroImage.linkAnnotation(fileAnnotation)
-        return fileAnnotation, omeroImage
-    else:
-        return fileAnnotation, None
+    fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
+    output="Movie ROI figure", parenttype=commandArgs["Data_Type"], mimetype=format, desc=figLegend)
+    message += faMessage
+    
+    return fileAnnotation, message
 
 def runAsScript():
     """
@@ -783,22 +787,18 @@ See http://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/e
         for key in client.getInputKeys():
             if client.getInput(key):
                 commandArgs[key] = unwrap(client.getInput(key))
-
         print commandArgs
+        
         # call the main script, attaching resulting figure to Image. Returns the id of the originalFileLink child. (ID object, not value)
-        result = roiFigure(conn, commandArgs)
-        if result is not None:
-            fileAnnotation, image = result
-            fileAnnotation, image = result
-            message = "ROI Movie Figure created"
-            if image is not None:
-                message += " and attached to image %s"  % image.getName()
-            client.setOutput("File_Annotation", robject(fileAnnotation._obj)) # return this fileAnnotation to the client. 
-            client.setOutput("Message", rstring(message))
-        else:
-            client.setOutput("Message", rstring("No Figure Produced. See Error or Info for details"))
+        fileAnnotation, message = roiFigure(conn, commandArgs)
+        
+        # Return message and file annotation (if applicable) to the client 
+        client.setOutput("Message", rstring(message))        
+        if fileAnnotation is not None:
+            client.setOutput("File_Annotation", robject(fileAnnotation._obj))
 
-    finally: client.closeSession()
+    finally: 
+        client.closeSession()
 
 if __name__ == "__main__":
     runAsScript()

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -511,11 +511,10 @@ def roiFigure(conn, commandArgs):
     log("ROI figure created by OMERO on %s" % date.today())
     log("")
     
-    message=""
+    message="" # message to be returned to the client
     pixelIds = []
     imageIds = []
     imageLabels = []
-    omeroImage = None    # this is set as the first image, to link figure to
 
     # function for getting image labels.
     def getLabels(fullName, tagsList, pdList):
@@ -532,25 +531,21 @@ def roiFigure(conn, commandArgs):
             def getTags(name, tagsList, pdList):
                 return tagsList
             getLabels = getTags
-            
+    
+    # Get the images
+    images, logMessage = scriptUtil.getObjects(conn, commandArgs)
+    message += logMessage
+    if not images:
+        return None, message
+
+    # Attach figure to the first image
+    omeroImage = images[0]  
+          
     # process the list of images
     log("Image details:")
-    ids = commandArgs["IDs"]
-    images = list(conn.getObjects("Image",ids))
-
-    # Check images
-    if not images:
-       message += "No image found. "
-       return None, message
-    else:
-       if not len(images) == len(ids):
-           message += "Found %s out of %s image(s). " % (len(images), len(ids))
-
     for image in images:
        imageIds.append(image.getId())
        pixelIds.append(image.getPrimaryPixels().getId())
-
-    omeroImage = images[0]
               
     pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
     tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -690,8 +690,9 @@ def roiFigure(conn, commandArgs):
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
+    namespace = omero.constants.namespaces.NSCREATED+"/figure/movieROIFigure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie ROI figure", mimetype=mimetype, desc=figLegend)
+    output="Movie ROI figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -515,7 +515,6 @@ def roiFigure(conn, commandArgs):
     pixelIds = []
     imageIds = []
     imageLabels = []
-    imageNames = {}
     omeroImage = None    # this is set as the first image, to link figure to
 
     # function for getting image labels.
@@ -534,33 +533,31 @@ def roiFigure(conn, commandArgs):
                 return tagsList
             getLabels = getTags
             
-    # process the list of images. If imageIds is not set, script can't run.
+    # process the list of images
     log("Image details:")
     ids = commandArgs["IDs"]
-    for imageId in ids:
-        image = conn.getObject("Image", imageId)
-        if image == None:
-            print "Image not found for ID:", imageId
-            continue
-        imageIds.append(imageId)
-        if omeroImage is None:
-            omeroImage = image        # remember the first image to attach figure to
-        pixelIds.append(image.getPrimaryPixels().getId())
-        imageNames[imageId] = image.getName()
+    images = list(conn.getObjects("Image",ids))
 
-    if len(imageIds) == 0:
-        print "No image IDs specified."
-        message += "No image found. "
-        return None, message
+    # Check images
+    if not images:
+       message += "No image found. "
+       return None, message
     else:
-        if not len(imageIds) == len(ids):
-            message += "Found %s out of %s image(s). " % (len(imageIds), len(ids))
-            
+       if not len(images) == len(ids):
+           message += "Found %s out of %s image(s). " % (len(images), len(ids))
+
+    for image in images:
+       imageIds.append(image.getId())
+       pixelIds.append(image.getPrimaryPixels().getId())
+
+    omeroImage = images[0]
+              
     pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
     tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)
     # Build a legend entry for each image
-    for iId in imageIds:
-        name = imageNames[iId]
+    for image in images:
+        name = image.getName()
+        iId = image.getId()
         imageDate = image.getAcquisitionDate()
         tagsList = tagMap[iId]
         pdList = pdMap[iId]

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -689,15 +689,17 @@ def roiFigure(conn, commandArgs):
     if format == PNG:
         output = output + ".png"
         fig.save(output, "PNG")
+        mimetype = "image/png"
     else:
         output = output + ".jpg"
         fig.save(output)
+        mimetype = "image/jpeg"
     
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage, 
-    output="Movie ROI figure", parenttype=commandArgs["Data_Type"], mimetype=format, desc=figLegend)
+    output="Movie ROI figure", parenttype=commandArgs["Data_Type"], mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -763,7 +763,7 @@ def roiFigure(conn, commandArgs):
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="ROI Split figure", parenttype=commandArgs["Data_Type"], mimetype=mimetype, desc=figLegend)
+        output="ROI Split figure", mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -756,8 +756,9 @@ def roiFigure(conn, commandArgs):
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
+    namespace = omero.constants.namespaces.NSCREATED+"/figure/ROISplitFigure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="ROI Split figure", mimetype=mimetype, desc=figLegend)
+        output="ROI Split figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -749,15 +749,17 @@ def roiFigure(conn, commandArgs):
     if format == PNG:
         output = output + ".png"
         fig.save(output, "PNG")
+        mimetype = "image/png"
     else:
         output = output + ".jpg"
         fig.save(output)
+        mimetype = "image/jpeg"
     
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="ROI Split figure", parenttype=commandArgs["Data_Type"], mimetype=format, desc=figLegend)
+        output="ROI Split figure", parenttype=commandArgs["Data_Type"], mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -41,6 +41,7 @@ import omero.scripts as scripts
 import omero.util.imageUtil as imgUtil
 import omero.util.figureUtil as figUtil
 import omero.util.script_utils as scriptUtil
+from omero.gateway import BlitzGateway
 from omero.rtypes import *
 # import util.figureUtil as figUtil    # need to comment out for upload to work. But need import for script to work!!
 import getopt, sys, os, subprocess
@@ -383,7 +384,7 @@ def getVerticalLabels(labels, font, textGap):
     return textCanvas.rotate(90)
     
     
-def getSplitView(session, imageIds, pixelIds, splitIndexes, channelNames, mergedNames, colourChannels, mergedIndexes, 
+def getSplitView(conn, imageIds, pixelIds, splitIndexes, channelNames, mergedNames, colourChannels, mergedIndexes, 
         mergedColours, width, height, imageLabels, spacer, algorithm, stepping, scalebar, 
         overlayColour, roiZoom, roiLabel):
     """ This method makes a figure of a number of images, arranged in rows with each row being the split-view
@@ -407,15 +408,15 @@ def getSplitView(session, imageIds, pixelIds, splitIndexes, channelNames, merged
     @ spacer        the gap between images and around the figure. Doubled between rows. 
     """
     
-    roiService = session.getRoiService()
-    re = session.createRenderingEngine()
-    queryService = session.getQueryService()    # only needed for movie
+    roiService = conn.getRoiService()
+    re = conn.createRenderingEngine()
+    queryService = conn.getQueryService()    # only needed for movie
     
     # establish dimensions and roiZoom for the primary image
     # getTheseValues from the server
     rect = getRectangle(roiService, imageIds[0], roiLabel)
     if rect == None:
-        raise("No ROI found for the first image.")
+        raise Exception("No ROI found for the first image.")
     roiX, roiY, roiWidth, roiHeight, yMin, yMax, tMin, tMax = rect
     
     roiOutline = ((max(width, height)) / 200 ) + 1
@@ -541,7 +542,7 @@ def getSplitView(session, imageIds, pixelIds, splitIndexes, channelNames, merged
     return figureCanvas
             
 
-def roiFigure(session, commandArgs):    
+def roiFigure(conn, commandArgs):
     """
         This processes the script parameters, adding defaults if needed. 
         Then calls a method to make the figure, and finally uploads and attaches this to the primary image.
@@ -553,13 +554,6 @@ def roiFigure(session, commandArgs):
         
         @return:     the id of the originalFileLink child. (ID object, not value) 
     """
-    
-    # create the services we're going to need. 
-    metadataService = session.getMetadataService()
-    queryService = session.getQueryService()
-    updateService = session.getUpdateService()
-    rawFileStore = session.createRawFileStore()
-    containerService = session.getContainerService()
     
     log("ROI figure created by OMERO on %s" % date.today())
     log("")
@@ -588,27 +582,26 @@ def roiFigure(session, commandArgs):
             
     # process the list of images. If imageIds is not set, script can't run. 
     log("Image details:")
-    for idCount, imageId in enumerate(commandArgs["IDs"]):
-        iId = long(imageId.getValue())
-        image = containerService.getImages("Image", [iId], None)[0]
+    for imageId in commandArgs["IDs"]:
+        image = conn.getObject("Image", imageId)
         if image == None:
-            print "Image not found for ID:", iId
+            print "Image not found for ID:", imageId
             continue
-        imageIds.append(iId)
-        if idCount == 0:
+        imageIds.append(imageId)
+        if omeroImage is None:
             omeroImage = image        # remember the first image to attach figure to
-        pixelIds.append(image.getPrimaryPixels().getId().getValue())
-        imageNames[iId] = image.getName().getValue()
+        pixelIds.append(image.getPrimaryPixels().getId())
+        imageNames[imageId] = image.getName()
     
     if len(imageIds) == 0:
         print "No image IDs specified."    
             
-    pdMap = figUtil.getDatasetsProjectsFromImages(queryService, imageIds)    # a map of imageId : list of (project, dataset) names. 
-    tagMap = figUtil.getTagsFromImages(metadataService, imageIds)
+    pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
+    tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)
     # Build a legend entry for each image
     for iId in imageIds:
         name = imageNames[iId]
-        imageDate = image.getAcquisitionDate().getValue()
+        imageDate = image.getAcquisitionDate()
         tagsList = tagMap[iId]
         pdList = pdMap[iId]
         
@@ -622,13 +615,10 @@ def roiFigure(session, commandArgs):
         imageLabels.append(getLabels(name, tagsList, pdList))
     
     # use the first image to define dimensions, channel colours etc. 
-    pixelsId = pixelIds[0]
-    pixels = queryService.get("Pixels", pixelsId)
-
-    sizeX = pixels.getSizeX().getValue();
-    sizeY = pixels.getSizeY().getValue();
-    sizeZ = pixels.getSizeZ().getValue();
-    sizeC = pixels.getSizeC().getValue();
+    sizeX = omeroImage.getSizeX();
+    sizeY = omeroImage.getSizeY();
+    sizeZ = omeroImage.getSizeZ();
+    sizeC = omeroImage.getSizeC();
 
     
     width = sizeX
@@ -734,7 +724,7 @@ def roiFigure(session, commandArgs):
         
     spacer = (width/50) + 2
     
-    fig = getSplitView(session, imageIds, pixelIds, splitIndexes, channelNames, mergedNames, colourChannels, mergedIndexes, 
+    fig = getSplitView(conn, imageIds, pixelIds, splitIndexes, channelNames, mergedNames, colourChannels, mergedIndexes, 
             mergedColours, width, height, imageLabels, spacer, algorithm, stepping, scalebar, overlayColour, roiZoom, roiLabel)
     
     if fig == None:        # e.g. No ROIs found
@@ -820,15 +810,16 @@ See https://www.openmicroscopy.org/site/support/omero4/getting-started/tutorial/
     try:
         session = client.getSession()
         commandArgs = {}
-    
+        conn = BlitzGateway(client_obj=client)
+
         # process the list of args above. 
         for key in client.getInputKeys():
             if client.getInput(key):
-                commandArgs[key] = client.getInput(key).getValue()
+                commandArgs[key] =  unwrap(client.getInput(key))
     
         print commandArgs
         # call the main script, attaching resulting figure to Image. Returns the id of the originalFileLink child. (ID object, not value)
-        fileAnnotation = roiFigure(session, commandArgs)
+        fileAnnotation = roiFigure(conn, commandArgs)
         # return this fileAnnotation to the client. 
         if fileAnnotation:
             client.setOutput("Message", rstring("ROI Split Figure Created"))

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -756,7 +756,7 @@ def roiFigure(conn, commandArgs):
     # Use util method to upload the figure 'output' to the server, attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description. 
     # Returns the id of the originalFileLink child. (ID object, not value)
-    namespace = omero.constants.namespaces.NSCREATED+"/figure/ROISplitFigure"
+    namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/ROI_Split_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
         output="ROI Split figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -558,11 +558,10 @@ def roiFigure(conn, commandArgs):
     log("ROI figure created by OMERO on %s" % date.today())
     log("")
     
-    message=""
+    message="" # message to be returned to the client
     pixelIds = []
     imageIds = []
     imageLabels = []
-    omeroImage = None    # this is set as the first image, to link figure to
 
     # function for getting image labels.
     def getLabels(fullName, tagsList, pdList):
@@ -580,25 +579,20 @@ def roiFigure(conn, commandArgs):
                 return tagsList
             getLabels = getTags
             
+    # Get the images
+    images, logMessage = scriptUtil.getObjects(conn, commandArgs)
+    message += logMessage
+    if not images:
+        return None, message
+
+    # Attach figure to the first image
+    omeroImage = images[0]
+    
     # process the list of images. If imageIds is not set, script can't run. 
     log("Image details:")
-    ids = commandArgs["IDs"]
-    images = list(conn.getObjects("Image",ids))
-    
-    # Check images
-    if not images:
-        message += "No image found. "
-        return None, message
-    else:
-        if not len(images) == len(ids):
-            message += "Found %s out of %s image(s). " % (len(images), len(ids))
-        
     for image in images:
         imageIds.append(image.getId())
         pixelIds.append(image.getPrimaryPixels().getId())
-                
-    omeroImage = images[0] # remember the first image to attach figure to
-
             
     pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
     tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
@@ -637,7 +637,7 @@ def splitViewFigure(conn, scriptParams):
     # Upload the figure 'output' to the server, creating a file annotation and attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description.
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="Split view figure", parenttype=scriptParams["Data_Type"], mimetype=mimetype, desc=figLegend)
+        output="Split view figure", mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
@@ -482,11 +482,10 @@ def splitViewFigure(conn, scriptParams):
     log("Split-View figure created by OMERO on %s" % date.today())
     log("")
     
-    message=""
+    message="" # message to be returned to the client
     imageIds = []
     pixelIds = []
     imageLabels = []
-    omeroImage = None    # this is set as the first image, to link figure to
 
     # function for getting image labels.
     def getLabels(fullName, tagsList, pdList):
@@ -502,25 +501,21 @@ def splitViewFigure(conn, scriptParams):
         def getTags(name, tagsList, pdList):
             return tagsList
         getLabels = getTags
+   
+    # Get the images
+    images, logMessage = scriptUtil.getObjects(conn, scriptParams)
+    message += logMessage
+    if not images:
+        return None, message
+
+    # Attach figure to the first image
+    omeroImage = images[0] 
             
     # process the list of images
     log("Image details:")
-    ids = scriptParams["IDs"]
-    images = list(conn.getObjects("Image",ids))
-
-    # Check images
-    if not images:
-        message += "No image found. "
-        return None, message
-    else:
-        if not len(images) == len(ids):
-            message += "Found %s out of %s image(s). " % (len(images), len(ids))
-
     for image in images:
         imageIds.append(image.getId())
         pixelIds.append(image.getPrimaryPixels().getId())
-
-    omeroImage = images[0] # remember the first image to attach figure to
     
     pdMap = figUtil.getDatasetsProjectsFromImages(conn.getQueryService(), imageIds)    # a map of imageId : list of (project, dataset) names. 
     tagMap = figUtil.getTagsFromImages(conn.getMetadataService(), imageIds)

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
@@ -631,7 +631,7 @@ def splitViewFigure(conn, scriptParams):
 
     # Upload the figure 'output' to the server, creating a file annotation and attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description.
-    namespace = omero.constants.namespaces.NSCREATED+"/figure/splitViewFigure"
+    namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Split_View_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
         output="Split view figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
@@ -625,14 +625,16 @@ def splitViewFigure(conn, scriptParams):
     if format == PNG:
         output = output + ".png"
         fig.save(output, "PNG")
+        mimetype = "image/png"
     else:
         output = output + ".jpg"
         fig.save(output)
+        mimetype = "image/jpeg"
 
     # Upload the figure 'output' to the server, creating a file annotation and attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description.
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="Split view figure", parenttype=scriptParams["Data_Type"], mimetype=format, desc=figLegend)
+        output="Split view figure", parenttype=scriptParams["Data_Type"], mimetype=mimetype, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Split_View_Figure.py
@@ -631,8 +631,9 @@ def splitViewFigure(conn, scriptParams):
 
     # Upload the figure 'output' to the server, creating a file annotation and attaching it to the omeroImage, adding the 
     # figLegend as the fileAnnotation description.
+    namespace = omero.constants.namespaces.NSCREATED+"/figure/splitViewFigure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, omeroImage,
-        output="Split view figure", mimetype=mimetype, desc=figLegend)
+        output="Split view figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage
     
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Thumbnail_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Thumbnail_Figure.py
@@ -289,7 +289,7 @@ def makeThumbnailFigure(conn, scriptParams):
         figure.save(output)
         mimetype = "image/jpeg"
 
-    namespace = omero.constants.namespaces.NSCREATED+"/figure/thumbnailFigure"
+    namespace = omero.constants.namespaces.NSCREATED+"/omero/figure_scripts/Thumbnail_Figure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, parent,
         output="Thumbnail figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Thumbnail_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Thumbnail_Figure.py
@@ -289,8 +289,9 @@ def makeThumbnailFigure(conn, scriptParams):
         figure.save(output)
         mimetype = "image/jpeg"
 
+    namespace = omero.constants.namespaces.NSCREATED+"/figure/thumbnailFigure"
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, parent,
-        output="Thumbnail figure", mimetype=mimetype, desc=figLegend)
+        output="Thumbnail figure", mimetype=mimetype, ns=namespace, desc=figLegend)
     message += faMessage
 
     return fileAnnotation, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Thumbnail_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Thumbnail_Figure.py
@@ -206,38 +206,29 @@ def makeThumbnailFigure(conn, scriptParams):
     log("Thumbnail figure created by OMERO")
     log("")
 
-    parent = None        # figure will be attached to this object 
     message=""
     imageIds = []
     datasetIds = []
     
-    dataType = scriptParams["Data_Type"]
-    if dataType == "Image":
-        imageIds = scriptParams["IDs"]
-        if "Parent_ID" in scriptParams and len(imageIds) > 1:
-            pId = scriptParams["Parent_ID"]
-            parenttype = "Dataset"
-            parent = conn.getObject("Dataset", pId)               
-                
-        if parent == None:
-            parenttype = "Image"
-            parent = conn.getObject("Image", imageIds[0])
-                
-    else:   # Dataset
-        datasetIds = scriptParams["IDs"]
-        if "Parent_ID" in scriptParams and len(datasetIds) > 1:
-            pId = scriptParams["Parent_ID"]
-            parenttype = "Project"
-            parent = conn.getObject(parenttype, pId)
+    # Get the objects (images or datasets)
+    objects, logMessage = scriptUtil.getObjects(conn, scriptParams)
+    message += logMessage
+    if not objects:
+       return None, message
+           
+    # Get parent
+    parent = None
+    if "Parent_ID" in scriptParams and len(scriptParams["IDs"]) > 1:
+        if dataType == "Image":
+            parent = conn.getObject("Dataset", scriptParams["Parent_ID"])
+        else:
+            parent = conn.getObject("Project", scriptParams["Parent_ID"])
 
-        if parent is None:
-            parenttype = "Dataset"
-            parent = conn.getObject("Dataset", datasetIds[0])
+    if parent is None:
+        parent = objects[0] # Attach figure to the first object
 
-    log("Figure will be linked to %s: %s" % (parenttype, parent.getName()))
-    
-    if len(imageIds) == 0 and len(datasetIds) == 0:
-        print "No image IDs or dataset IDs found"       
+    parentClass = parent.OMERO_CLASS
+    log("Figure will be linked to %s%s: %s" % (parentClass[0].lower(), parentClass[1:], parent.getName()))     
     
     tagIds = []
     if "Tag_IDs" in scriptParams:
@@ -255,31 +246,27 @@ def makeThumbnailFigure(conn, scriptParams):
     figHeight = 0
     figWidth = 0
     dsCanvases = []
-
-    for datasetId in datasetIds:
-        dataset = conn.getObject("Dataset", datasetId)
-        if dataset == None:
-            log("No dataset found for ID: %s" % datasetId)
-            continue
-        datasetName = dataset.getName()
-        images = list(dataset.listChildren())
-        log("Dataset: %s     ID: %d" % (datasetName, datasetId))
-        dsCanvas = paintDatasetCanvas(conn, images, datasetName, tagIds, showUntagged, length=thumbSize, colCount=maxColumns)
-        if dsCanvas == None:
-            continue
-        dsCanvases.append(dsCanvas)
-        figHeight += dsCanvas.size[1]
-        figWidth = max(figWidth, dsCanvas.size[0])
+    
+    if scriptParams["Data_Type"] == "Dataset": 
+        for dataset in objects:
+            log("Dataset: %s     ID: %d" % (dataset.getName(), dataset.getId()))
+            images = list(dataset.listChildren())
+            dsCanvas = paintDatasetCanvas(conn, images, dataset.getName(), tagIds, showUntagged, length=thumbSize, colCount=maxColumns)
+            if dsCanvas == None:
+                continue
+            dsCanvases.append(dsCanvas)
+            figHeight += dsCanvas.size[1]
+            figWidth = max(figWidth, dsCanvas.size[0])
         
-    if len(datasetIds) == 0:
-        images = list(conn.getObjects("Image", imageIds))
-        imageCanvas = paintDatasetCanvas(conn, images, "", tagIds, showUntagged, length=thumbSize, colCount=maxColumns)
+    else:
+        imageCanvas = paintDatasetCanvas(conn, objects, "", tagIds, showUntagged, length=thumbSize, colCount=maxColumns)
         dsCanvases.append(imageCanvas)
         figHeight += imageCanvas.size[1]
         figWidth = max(figWidth, imageCanvas.size[0])
     
     if len(dsCanvases) == 0:
-        return None
+        return None, message
+        
     figure = Image.new("RGB", (figWidth, figHeight), WHITE)
     y = 0
     for ds in dsCanvases:
@@ -303,7 +290,7 @@ def makeThumbnailFigure(conn, scriptParams):
         mimetype = "image/jpeg"
 
     fileAnnotation, faMessage = scriptUtil.createLinkFileAnnotation(conn, output, parent,
-        output="Thumbnail figure figure", parenttype=parenttype, mimetype=mimetype, desc=figLegend)
+        output="Thumbnail figure", mimetype=mimetype, desc=figLegend)
     message += faMessage
 
     return fileAnnotation, message

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -341,7 +341,7 @@ def createLinkFileAnnotation(conn, localPath, parent, output="Output", parenttyp
         if parent is not None:
             if parent.canAnnotate():
                 parentClass = parent.OMERO_CLASS
-                message += " and attached to %s %s."  % (parentClass[0].lower+parentClass[1:], parent.getName())                
+                message += " and attached to %s%s %s."  % (parentClass[0].lower(), parentClass[1:], parent.getName())                
                 parent.linkAnnotation(fileAnnotation)
             else:
                 message += " but could not be attached."
@@ -350,6 +350,27 @@ def createLinkFileAnnotation(conn, localPath, parent, output="Output", parenttyp
         fileAnnotation = None
     return fileAnnotation, message
     
+def getObjects(conn, params):
+    """
+    Get the objects specified by the script parameters. 
+    Assume the parameters contain the keys IDs and Data_Type
+
+    @param conn:            The L{omero.gateway.BlitzGateway} connection.
+    @param params:          The script parameters
+    @return:                The valid objects and a log message
+    """
+  
+    dataType = params["Data_Type"]
+    ids = params["IDs"]
+    objects = list(conn.getObjects(dataType,ids))
+
+    message = ""
+    if not objects:
+        message += "No %s%s found. " % (dataType[0].lower(), dataType[1:])
+    else:
+        if not len(objects) == len(ids):
+            message += "Found %s out of %s %s%s(s). " % (len(objects), len(ids), dataType[0].lower(), dataType[1:])
+    return objects, message
     
 def addAnnotationToImage(updateService, image, annotation):
     """

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -340,7 +340,8 @@ def createLinkFileAnnotation(conn, localPath, parent, output="Output", parenttyp
         message = "%s created" % output
         if parent is not None:
             if parent.canAnnotate():
-                message += " and attached to %s %s."  % (parenttype, parent.getName())                
+                parentClass = parent.OMERO_CLASS
+                message += " and attached to %s %s."  % (parentClass[0].lower+parentClass[1:], parent.getName())                
                 parent.linkAnnotation(fileAnnotation)
             else:
                 message += " but could not be attached."

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -319,6 +319,35 @@ def uploadAndAttachFile(queryService, updateService, rawFileStore, parent, local
     uploadFile(rawFileStore, originalFile, localName)
     fileLink = attachFileToParent(updateService, parent, originalFile, description, namespace)
     return fileLink.getChild()
+
+def createLinkFileAnnotation(conn, localPath, parent, output="Output", parenttype="Image", mimetype=None, desc=None, ns=None, origFilePathAndName=None):
+    """
+    Uploads a local file to the server, as an Original File and attaches it to the 
+    parent (Project, Dataset or Image)
+
+    @param conn:            The L{omero.gateway.BlitzGateway} connection.
+    @param parent:          The ProjectI or DatasetI or ImageI to attach file to
+    @param localPath:       Full Name (and path) of the file location to upload. String
+    @param mimetype:        The original file mimetype. E.g. "PNG". String
+    @param description:     Optional description for the file annotation. String
+    @param namespace:       Namespace to set for the original file
+    @param 
+    @param origFilePathName:    The /path/to/file/fileName.ext you want on the server. If none, use output as name
+    @return:                The originalFileLink child (FileAnnotationI) and a log message
+    """
+    if os.path.exists(localPath):
+        fileAnnotation = conn.createFileAnnfromLocalFile(localPath, origFilePathAndName=origFilePathAndName, mimetype=mimetype, ns=ns, desc=desc)
+        message = "%s created" % output
+        if parent is not None:
+            if parent.canAnnotate():
+                message += " and attached to %s %s."  % (parenttype, parent.getName())                
+                parent.linkAnnotation(fileAnnotation)
+            else:
+                message += " but could not be attached."
+    else:
+        message = "%s not created." % output
+        fileAnnotation = None
+    return fileAnnotation, message
     
     
 def addAnnotationToImage(updateService, image, annotation):


### PR DESCRIPTION
Modify figure scripts logic to:
- check input objects and return message if applicable
- separate file annotation creation from linking and return message in client
- add namespace to file annotation

Tests have been performed on a rw-- group with 2 users and the image/dataset tested belonging to the group owner (see [test script](https://gist.github.com/2788173)).
