### PR TITLE
Figure scripts

### DIFF
--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -539,7 +539,7 @@ def roiFigure(conn, commandArgs):
         return None, message
     
     # Check for rectangular ROIs and filter images list
-    images = [image for image in images if scriptUtil.hasROI(conn, image, "Rect")]
+    images = [image for image in images if image.getROICount("Rect")>0]
     if not images:
         message += "No rectangle ROI found."
         return None, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/Movie_ROI_Figure.py
@@ -537,7 +537,13 @@ def roiFigure(conn, commandArgs):
     message += logMessage
     if not images:
         return None, message
-
+    
+    # Check for rectangular ROIs and filter images list
+    images = [image for image in images if scriptUtil.hasROI(conn, image, "Rect")]
+    if not images:
+        message += "No rectangle ROI found."
+        return None, message
+    
     # Attach figure to the first image
     omeroImage = images[0]  
           
@@ -663,8 +669,10 @@ def roiFigure(conn, commandArgs):
     #fig.show()        # bug-fixing only
 
     if fig is None:
-        log("\nNo Figure produced - probably due to NO rectangle ROIs being found for the specified images")
-        return
+        logMessage = "No figure produced"
+        log("\n"+logMessage)
+        message += logMessage
+        return None, message
     figLegend = "\n".join(logStrings)
     
     #print figLegend    # bug fixing only

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -586,7 +586,7 @@ def roiFigure(conn, commandArgs):
         return None, message
     
     # Check for rectangular ROIs and filter images list
-    images = [image for image in images if scriptUtil.hasROI(conn, image, "Rect")]
+    images = [image for image in images if image.getROICount("Rect")>0]
     if not images:
         message += "No rectangle ROI found."
         return None, message

--- a/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
+++ b/components/tools/OmeroPy/scripts/omero/figure_scripts/ROI_Split_Figure.py
@@ -584,7 +584,13 @@ def roiFigure(conn, commandArgs):
     message += logMessage
     if not images:
         return None, message
-
+    
+    # Check for rectangular ROIs and filter images list
+    images = [image for image in images if scriptUtil.hasROI(conn, image, "Rect")]
+    if not images:
+        message += "No rectangle ROI found."
+        return None, message
+    
     # Attach figure to the first image
     omeroImage = images[0]
     
@@ -726,8 +732,11 @@ def roiFigure(conn, commandArgs):
     fig = getSplitView(conn, imageIds, pixelIds, splitIndexes, channelNames, mergedNames, colourChannels, mergedIndexes, 
             mergedColours, width, height, imageLabels, spacer, algorithm, stepping, scalebar, overlayColour, roiZoom, roiLabel)
     
-    if fig == None:        # e.g. No ROIs found
-        return                                                
+    if fig is None:
+        logMessage = "No figure produced"
+        log("\n"+logMessage)
+        message += logMessage
+        return None, message
     #fig.show()        # bug-fixing only
     
     log("")

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -366,6 +366,27 @@ def getObjects(conn, params):
             message += "Found %s out of %s %s%s(s). " % (len(objects), len(ids), dataType[0].lower(), dataType[1:])
     return objects, message
     
+def hasROI(conn, image, roitypes="Rect"):
+    """
+    Check if an image has a ROI of a given type
+
+    @param conn:            The L{omero.gateway.BlitzGateway} connection.
+    @param image:           The ImageI object
+    @param type:            A type of ROI ("Rect","Ellipse","Line",...)
+    @return:                True/false if a rectangular ROI is found
+    """
+    result = conn.getRoiService().findByImage(image.getId(),None)
+    for roi in result.rois:
+        for shape in roi.copyShapes():
+            if type(roitypes) == "list":
+                for roitype in roitypes:
+                    if isinstance(shape,getattr(omero.model,roitype)):
+                        return True
+            else:
+                if isinstance(shape,getattr(omero.model,roitypes)):
+                    return True
+    return False
+
 def addAnnotationToImage(updateService, image, annotation):
     """
     Add the annotation to an image.

--- a/components/tools/OmeroPy/src/omero/util/script_utils.py
+++ b/components/tools/OmeroPy/src/omero/util/script_utils.py
@@ -365,27 +365,6 @@ def getObjects(conn, params):
         if not len(objects) == len(ids):
             message += "Found %s out of %s %s%s(s). " % (len(objects), len(ids), dataType[0].lower(), dataType[1:])
     return objects, message
-    
-def hasROI(conn, image, roitypes="Rect"):
-    """
-    Check if an image has a ROI of a given type
-
-    @param conn:            The L{omero.gateway.BlitzGateway} connection.
-    @param image:           The ImageI object
-    @param type:            A type of ROI ("Rect","Ellipse","Line",...)
-    @return:                True/false if a rectangular ROI is found
-    """
-    result = conn.getRoiService().findByImage(image.getId(),None)
-    for roi in result.rois:
-        for shape in roi.copyShapes():
-            if type(roitypes) == "list":
-                for roitype in roitypes:
-                    if isinstance(shape,getattr(omero.model,roitype)):
-                        return True
-            else:
-                if isinstance(shape,getattr(omero.model,roitypes)):
-                    return True
-    return False
 
 def addAnnotationToImage(updateService, image, annotation):
     """

--- a/components/tools/OmeroPy/test/integration/rois.py
+++ b/components/tools/OmeroPy/test/integration/rois.py
@@ -32,6 +32,77 @@ class TestRois(lib.ITest):
 
         svc = self.client.sf.getRoiService()
         res = svc.findByImage(img.id.val, None)
+    
+    def testROICountTypes(self):
+        """
+        Test ROI counting method
+        """
+        
+        img = self.new_image("")
+        roi1 = omero.model.RoiI()
+        roi1.addShape(omero.model.RectI())
+        roi1.addShape(omero.model.EllipseI())
+        img.addRoi(roi1)
+        roi2 = omero.model.RoiI()
+        roi2.addShape(omero.model.RectI())
+        img.addRoi(roi2)
+        img = self.update.saveAndReturnObject(img)
 
+        from omero.gateway import ImageWrapper, BlitzGateway
+        
+        conn = BlitzGateway(client_obj = self.client)
+        wrapper = ImageWrapper(conn, img)
+        
+        self.assertEqual(wrapper.getROICount(),3)
+        self.assertEqual(wrapper.getROICount("Rect"),2)
+        self.assertEqual(wrapper.getROICount("Ellipse"),1)
+        self.assertEqual(wrapper.getROICount("Line"),0)
+        self.assertEqual(wrapper.getROICount(["Rect","Ellipse"]),3)
+
+    def testROICountPermissions(self):
+        """
+        Test ROI counting method with permissions level
+        """
+        
+        # Create group with two member and one image
+        group = self.new_group(perms="rwrw--")
+        owner = self.new_client(group=group) # Owner of share
+        member = self.new_client(group=group) # Member of group
+        img = self.createTestImage(session=owner.sf)
+
+        # ROI 1 (rectangle) created by owner      
+        roi1 = omero.model.RoiI()
+        roi1.addShape(omero.model.RectI())
+        roi1.setImage(img)
+        roi1  = owner.sf.getUpdateService().saveAndReturnObject(roi1)
+
+        # ROI 2 (ellipse) created by member 
+        roi2 = omero.model.RoiI()
+        roi2.addShape(omero.model.EllipseI())
+        roi2.setImage(img)
+        roi2  = member.sf.getUpdateService().saveAndReturnObject(roi2)
+
+        from omero.gateway import ImageWrapper, BlitzGateway
+
+        # Owner gateway
+        conn = BlitzGateway(client_obj = owner)
+        wrapper = ImageWrapper(conn, img)
+        
+        self.assertEqual(wrapper.getROICount("Ellipse"),1)
+        self.assertEqual(wrapper.getROICount("Ellipse",None),1)
+        self.assertEqual(wrapper.getROICount("Ellipse",1),0)
+        self.assertEqual(wrapper.getROICount("Rect"),1)
+        self.assertEqual(wrapper.getROICount("Rect",None),1)
+        self.assertEqual(wrapper.getROICount("Rect",1),1)
+        
+        # Member gateway
+        conn = BlitzGateway(client_obj = member)
+        wrapper = ImageWrapper(conn, img)
+            
+        self.assertEqual(wrapper.getROICount("Ellipse"),1)
+        self.assertEqual(wrapper.getROICount("Ellipse",1),1)
+        self.assertEqual(wrapper.getROICount("Rect"),1)
+        self.assertEqual(wrapper.getROICount("Rect",1),0)
+    
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add getROICount() utility in BlitzGateway (tests in test/integration/rois.py)
- Use it in figure scripts to check number of Images with valid rectangle ROIs

NB: see also comments in PR #9
