### PR TITLE
Tickets/9020

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1061,7 +1061,6 @@ def jsonp (f):
             if server_id is None:
                 server_id = request.session['connector'].server_id
             kwargs['server_id'] = server_id
-            conn = kwargs.get('conn', None)
             rv = f(request, *args, **kwargs)
             if kwargs.get('_raw', False):
                 return rv

--- a/components/tools/OmeroWeb/omeroweb/webgateway/views.py
+++ b/components/tools/OmeroWeb/omeroweb/webgateway/views.py
@@ -1274,8 +1274,8 @@ def imageMarshal (image, key=None):
             rv = None
     return rv
 
-@jsonp
 @login_required()
+@jsonp
 def imageData_json (request, conn=None, _internal=False, **kwargs):
     """
     Get a dict with image information
@@ -1295,8 +1295,8 @@ def imageData_json (request, conn=None, _internal=False, **kwargs):
     rv = imageMarshal(image, key)
     return rv
 
-@jsonp
 @login_required()
+@jsonp
 def wellData_json (request, conn=None, _internal=False, **kwargs):
     """
     Get a dict with image information
@@ -1319,8 +1319,8 @@ def wellData_json (request, conn=None, _internal=False, **kwargs):
     rv = well.simpleMarshal(xtra=xtra)
     return rv
 
-@jsonp
 @login_required()
+@jsonp
 def plateGrid_json (request, pid, field=0, conn=None, **kwargs):
     """
     """
@@ -1365,8 +1365,8 @@ def plateGrid_json (request, pid, field=0, conn=None, **kwargs):
         rv = simplejson.loads(rv)
     return rv
 
-@jsonp
 @login_required()
+@jsonp
 def listImages_json (request, did, conn=None, **kwargs):
     """
     lists all Images in a Dataset, as json
@@ -1387,8 +1387,8 @@ def listImages_json (request, did, conn=None, **kwargs):
     xtra = {'thumbUrlPrefix': kwargs.get('urlprefix', urlprefix)}
     return map(lambda x: x.simpleMarshal(xtra=xtra), dataset.listChildren())
 
-@jsonp
 @login_required()
+@jsonp
 def listWellImages_json (request, did, conn=None, **kwargs):
     """
     lists all Images in a Well, as json
@@ -1409,8 +1409,8 @@ def listWellImages_json (request, did, conn=None, **kwargs):
     xtra = {'thumbUrlPrefix': kwargs.get('urlprefix', urlprefix)}
     return map(lambda x: x.getImage() and x.getImage().simpleMarshal(xtra=xtra), well.listChildren())
 
-@jsonp
 @login_required()
+@jsonp
 def listDatasets_json (request, pid, conn=None, **kwargs):
     """
     lists all Datasets in a Project, as json
@@ -1428,8 +1428,8 @@ def listDatasets_json (request, pid, conn=None, **kwargs):
         return HttpResponse('[]', mimetype='application/javascript')
     return [x.simpleMarshal(xtra={'childCount':0}) for x in project.listChildren()]
 
-@jsonp
 @login_required()
+@jsonp
 def datasetDetail_json (request, did, conn=None, **kwargs):
     """
     return json encoded details for a dataset
@@ -1438,8 +1438,8 @@ def datasetDetail_json (request, did, conn=None, **kwargs):
     ds = conn.getObject("Dataset", did)
     return ds.simpleMarshal()
 
-@jsonp
 @login_required()
+@jsonp
 def listProjects_json (request, conn=None, **kwargs):
     """
     lists all Projects, as json
@@ -1455,8 +1455,8 @@ def listProjects_json (request, conn=None, **kwargs):
         rv.append( {'id': pr.id, 'name': pr.name, 'description': pr.description or ''} )
     return rv
 
-@jsonp
 @login_required()
+@jsonp
 def projectDetail_json (request, pid, conn=None, **kwargs):
     """
     grab details from one specific project
@@ -1509,8 +1509,8 @@ def searchOptFromRequest (request):
         return {}
 
 @TimeIt(logging.INFO)
-@jsonp
 @login_required()
+@jsonp
 def search_json (request, conn=None, **kwargs):
     """
     Search for objects in blitz.
@@ -1646,8 +1646,8 @@ def list_compatible_imgs_json (request, iid, conn=None, **kwargs):
         json_data = '%s(%s)' % (r['callback'], json_data)
     return HttpResponse(json_data, mimetype='application/javascript')
 
-@jsonp
 @login_required()
+@jsonp
 def copy_image_rdef_json (request, conn=None, _internal=False, **kwargs):
     """
     Copy the rendering settings from one image to a list of images.
@@ -1694,8 +1694,8 @@ def copy_image_rdef_json (request, conn=None, _internal=False, **kwargs):
 #        json_data = '%s(%s)' % (r['callback'], json_data)
 #    return HttpResponse(json_data, mimetype='application/javascript')
 
-@jsonp
 @login_required()
+@jsonp
 def reset_image_rdef_json (request, iid, conn=None, **kwargs):
     """
     Try to remove all rendering defs the logged in user has for this image.
@@ -1890,8 +1890,8 @@ def test (request):
     c = Context(request,context)
     return HttpResponse(t.render(c))
 
-@jsonp
 @login_required(isAdmin=True)
+@jsonp
 def su (request, user, conn=None, **kwargs):
     """
     If current user is admin, switch the session to a new connection owned by 'user'


### PR DESCRIPTION
If the jsonp decorator precedes the login_required and user is not already logged in, there will be no 'connector' variable in the django session, which fails as described on #9020.

Handling that in jsonp seems redundant as the login logic is already taken care of, we just need to change the decorator order.
