### PR TITLE
Robot build path

### DIFF
--- a/components/tests/ui/build.xml
+++ b/components/tests/ui/build.xml
@@ -74,12 +74,15 @@
         <copy todir="${reports.insight}/jars" verbose="yes" flatten="yes" failonerror="no">
             <fileset dir="${target.dir}">
                 <include name="**/*.jar" />
-                <exclude name="**/insight-${omero.version}.jar"/>
                 <exclude name="**/OmeroImporter-${omero.version}.jar"/>
+            </fileset>
+             <fileset dir="${lib.dir}">
+                <include name="**/*.jar"/>
+                <exclude name="**/ice-*.jar"/>
             </fileset>
         </copy>
         <exec executable="jybot" failonerror="false" dir="${reports.insight}">
-            <env key="CLASSPATH" value="${insight.dir}/OUT/dist/*:${lib.dir}/repository/*:${reports.insight}/jars/*"/>
+            <env key="CLASSPATH" value="${insight.dir}/OUT/dist/*:${reports.insight}/jars/*"/>
             <arg value="-d"/>
             <arg value="${reports.insight}"/>
             <arg value="${basedir}/testcases/insight/"/>


### PR DESCRIPTION
Fix path issue. Exclude ice jars not matching current version from the path.
