### PR TITLE
Fix pagination selection issue

### DIFF
--- a/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
+++ b/components/tools/OmeroWeb/omeroweb/webclient/static/webclient/javascript/ome.webclient.actions.js
@@ -247,10 +247,13 @@ OME.doPagination = function(page) {
         containerNode = OME.getTreeBestGuess(containerType, containerId);
     }
 
+    // Deselect all
+    datatree.deselect_all(true);
+
     // Set the page for that node in the tree and reload the tree section
     datatree.change_page(containerNode, page);
-    // Reselect the same node to trigger update
-    datatree.deselect_all(true);
+
+    // and then reselect the same node again to trigger update
     datatree.select_node(containerNode);
 
     return false;


### PR DESCRIPTION
This was being caused by data being loaded twice in error under the specific condition when pagination did a refresh of the current node when a node was already selected.

This modifies pagination so that the tree deselection happens before the tree refresh is triggered. This avoids the refresh operation itself triggering a selection change
