### PR TITLE
admin_only: default to full_admin semantics

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/fs.py
+++ b/components/tools/OmeroPy/src/omero/plugins/fs.py
@@ -786,12 +786,6 @@ Examples:
                 117,
                 "Log file not accessible for Fileset:%s" % args.fileset.id.val)
 
-    @admin_only()
-    def set_repo(self, args):
-        """Change configuration properties for single repositories
-        """
-        pass
-
     def get_managed_repo(self, client):
         """
         For the moment this assumes there's only one.

--- a/components/tools/OmeroPy/src/omero/plugins/ldap.py
+++ b/components/tools/OmeroPy/src/omero/plugins/ldap.py
@@ -95,7 +95,7 @@ to users.""")
         for x in (active, list, getdn, setdn, discover, create):
             x.add_login_arguments()
 
-    @admin_only()
+    @admin_only(full_admin=False)  # IConfig privilege
     def active(self, args):
         c = self.ctx.conn(args)
         ildap = c.sf.getLdapService()
@@ -105,7 +105,6 @@ to users.""")
         else:
             self.ctx.die(1, "No")
 
-    @admin_only()
     def list(self, args):
         c = self.ctx.conn(args)
         iadmin = c.sf.getAdminService()
@@ -132,7 +131,7 @@ to users.""")
                 count += 1
         self.ctx.out(str(tb.build()))
 
-    @admin_only()
+    @admin_only(full_admin=False)  # ILdap privilege
     def getdn(self, args):
         c = self.ctx.conn(args)
         iadmin = c.sf.getAdminService()
@@ -174,7 +173,7 @@ to users.""")
     def update_user(self, iupdate, user):
         iupdate.saveObject(user)
 
-    @admin_only()
+    @admin_only(full_admin=False)  # See update_user/update_group
     def setdn(self, args):
         c = self.ctx.conn(args)
         iupdate = c.sf.getUpdateService()
@@ -203,7 +202,7 @@ to users.""")
             elif isinstance(obj, Experimenter):
                 self.update_user(iupdate, obj)
 
-    @admin_only()
+    @admin_only(full_admin=False)  # ILdap privilege
     def discover(self, args):
         c = self.ctx.conn(args)
         ildap = c.sf.getLdapService()


### PR DESCRIPTION
The semantics of the admin_only have been changed by the
introduction of restricted admins. Whereas previously,
isAdmin (i.e. membership in the system group) implied
complete power, restricted admins are *also* in the
system group but may be missing a non-future-proof list
of privileges.

This restores the previous behavior of having admin_only
require full permissions by acquiring the current list
of privileges and checking against those of the user.

If the new "minimial-restricted-admin" logic is needed,
then use `@admin_only(full_admin=False)`.

See:
 * https://trello.com/c/4dvUYSjS/126-definition-of-ultimate-admin
 * https://github.com/openmicroscopy/openmicroscopy/pull/5494